### PR TITLE
Fix validation for changing stage when request is pending approval

### DIFF
--- a/maintenance_tier_validation/models/maintenance.py
+++ b/maintenance_tier_validation/models/maintenance.py
@@ -20,7 +20,8 @@ class MaintenanceRequest(models.Model):
     @api.constrains('stage_id')
     def _constraint_stage_id(self):
         for rec in self:
-            if rec.state != 'confirm':
+
+            if rec.state == 'pending':
                 raise ValidationError(_("You can only change the stage when the request have been approved."))
 
     def _compute_state(self):


### PR DESCRIPTION
The previous code allowed changing the stage of a maintenance request regardless of its state. This was incorrect as the stage should only be modifiable when the request has been approved. This commit fixes the validation constraint to raise a ValidationError when attempting to change the stage of a request in the 'pending' state. This ensures data integrity and prevents inconsistent stage transitions.