### PR TITLE
Refactor maintenance module to include repair product configuration

### DIFF
--- a/mtr_custom/__manifest__.py
+++ b/mtr_custom/__manifest__.py
@@ -25,6 +25,7 @@
         'views/fleet_vehicle_views.xml',
         'views/maintenance_views.xml',
         'views/repair_views.xml',
+        'views/res_config_settings_views.xml',
         # report
         'report/maintenance_report.xml',
         'report/repair_report.xml',

--- a/mtr_custom/models/__init__.py
+++ b/mtr_custom/models/__init__.py
@@ -1,3 +1,5 @@
+from . import res_company
+from . import res_config_settings
 from . import fleet_vehicle_odometer
 from . import maintenance
 from . import repair

--- a/mtr_custom/models/maintenance.py
+++ b/mtr_custom/models/maintenance.py
@@ -11,6 +11,9 @@ class MaintenanceRequest(models.Model):
             'vehicle_id': self.vehicle_id.id,
         })
 
+    def _default_product_id(self):
+        return self.env.company.repair_product_id.id
+
     def action_view_repairs(self):
         action = self.env.ref('repair.action_repair_order_tree').read()[0]
         action['domain'] = [('maintenance_id', '=', self.id)]
@@ -45,7 +48,7 @@ class MaintenanceRequest(models.Model):
     general = fields.Boolean(string='General Checking')
     others = fields.Boolean(string='Others')
     repair_ids = fields.One2many(comodel_name='repair.order', inverse_name='maintenance_id', string='Repair')
-    product_id = fields.Many2one(comodel_name='product.product', string='Product')
+    product_id = fields.Many2one(comodel_name='product.product', default=_default_product_id, string='Product')
     repair_count = fields.Integer(string="Custom Repair Count", compute="_compute_custom_repair_count")
     maintenance_user_ids = fields.Many2many(comodel_name='res.users', related='maintenance_team_id.member_ids')
     maintenance_user_id = fields.Many2one(comodel_name='res.users', string='Mechanic User')

--- a/mtr_custom/models/res_company.py
+++ b/mtr_custom/models/res_company.py
@@ -1,0 +1,7 @@
+from odoo import api, fields, models, _
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    repair_product_id = fields.Many2one(comodel_name='product.product', string='Product')

--- a/mtr_custom/models/res_config_settings.py
+++ b/mtr_custom/models/res_config_settings.py
@@ -1,0 +1,7 @@
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    repair_product_id = fields.Many2one(related='company_id.repair_product_id', readonly=False)

--- a/mtr_custom/views/res_config_settings_views.xml
+++ b/mtr_custom/views/res_config_settings_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_res_config_settings_form_inherit_base_setup_res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.form.inherit.base.setup.res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('app_settings_block')]/div[@id='contacts_settings']" position="after">
+                <div id="invite_users">
+                    <h2>Repairs</h2>
+                    <div class="row mt16 o_settings_container" name="maintenances_setting_container">
+                        <div class="col-12 col-lg-6 o_setting_box" id="maintenance_details_settings">
+                            <field name="company_id" invisible="1" />
+                            <div class="o_setting_right_pane">
+                                <span class="o_form_label">Product Configuration</span>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."
+                                    aria-label="Values set here are company-specific." groups="base.group_multi_company"
+                                    role="img" />
+                                <div class="content-group">
+                                    <div class="mt16" groups="base.group_no_one">
+                                        <label for="repair_product_id" string="Product"
+                                            class="col-3 col-lg-3 o_light_label" />
+                                        <field name="repair_product_id" class="oe_inline"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The changes in this commit refactor the maintenance module to include a repair product configuration. Previously, the product for repairs was hardcoded, but now it can be configured on a per-company basis. This allows companies to set a specific product that will be used for repairs. The configuration is accessible under the "Repairs" section in the company settings, where users with the necessary privileges can select the desired product.

These changes provide flexibility and customization options for companies using the maintenance module. By allowing them to specify a repair product, it becomes easier to manage and track repairs associated with maintenance requests.