### PR TITLE
Add 'remarks' field to RepairFee model and maintenance report

### DIFF
--- a/mtr_custom/models/repair.py
+++ b/mtr_custom/models/repair.py
@@ -18,3 +18,9 @@ class RepairLine(models.Model):
     _inherit = "repair.line"
 
     remarks = fields.Char(string='Remarks')
+
+
+class RepairFee(models.Model):
+    _inherit = "repair.fee"
+
+    remarks = fields.Char(string='Remarks')

--- a/mtr_custom/report/maintenance_report.xml
+++ b/mtr_custom/report/maintenance_report.xml
@@ -420,6 +420,31 @@
                                                 </t>
                                             </tbody>
                                         </table><br/>
+                                        <div>C. Jasa Service</div><br/>
+                                        <table class="tables" style="width:100%;font-size: 14px;">
+                                            <thead>
+                                                <tr>
+                                                    <td class="tds" width="5%">No</td>
+                                                    <td class="tds" width="25%">Nama Jasa</td>
+                                                    <td class="tds" width="25%">Kode</td>
+                                                    <td class="tds" width="5%">Jumlah</td>
+                                                    <td class="tds" width="40%">Keterangan</td>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <t t-set="no" t-value="1"/>
+                                                <t t-foreach="repair.fees_lines" t-as="line">
+                                                    <tr>
+                                                        <td class="tds" width="5%"><t t-esc="no"/></td>
+                                                        <td class="tds" width="25%"><t t-esc="line.name"/></td>
+                                                        <td class="tds" width="25%"><t t-esc="line.product_id.default_code"/></td>
+                                                        <td class="tds" width="5%"><t t-esc="line.product_uom_qty"/></td>
+                                                        <td class="tds" width="40%"><t t-esc="line.remarks"/></td>
+                                                        <t t-set="no" t-value="no+1"/>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table><br/>
                                         <div style="page-break-inside: avoid;">
                                             <div>Tanggal : <t t-out="doc.request_date" t-options='{"widget": "date","format": "dd-MM-yyyy"}'/> </div><br/>
                                             <table style="width:100%;font-size: 16px;">

--- a/mtr_custom/views/repair_views.xml
+++ b/mtr_custom/views/repair_views.xml
@@ -9,7 +9,10 @@
                 <field name="tag_ids" position="after">
                     <field name="maintenance_id"/>
                 </field>
-                <xpath expr="//field[@name='operations']/tree//field[@name='price_subtotal']" position="after">
+                <xpath expr="//field[@name='operations']/tree/field[@name='price_subtotal']" position="after">
+                    <field name="remarks" optional="show"/>
+                </xpath>
+                <xpath expr="//field[@name='fees_lines']/tree/field[@name='price_subtotal']" position="after">
                     <field name="remarks" optional="show"/>
                 </xpath>
                 <page name="extra_info" position="inside">


### PR DESCRIPTION
This change adds a 'remarks' field to the 'RepairFee' model and the maintenance report. The 'remarks' field allows users to provide additional information or comments related to a repair service fee. This enhancement improves the clarity and comprehensibility of the maintenance report by including remarks for each service line item, facilitating better communication and documentation of the repair process.